### PR TITLE
Rovecomm3

### DIFF
--- a/src/RoveCommEthernet/RoveCommEthernet.cpp
+++ b/src/RoveCommEthernet/RoveCommEthernet.cpp
@@ -3,264 +3,376 @@
 
 #if defined(ENERGIA)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void RoveCommEthernet::begin(const uint8_t ip_octet_4, EthernetServer* TCPServer)
-{ 
-  //start UDP client and assigning board IP
+void RoveCommEthernet::begin(const uint8_t ip_octet_4, EthernetServer *TCPServer)
+{
+  // start UDP client and assigning board IP
   UDP.begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET, ip_octet_4);
-  //initializing the TCP server with the correct port
+  // initializing the TCP server with the correct port
   TCP.begin(TCPServer);
 }
 
-void RoveCommEthernet::begin(const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer* TCPServer)
-{ 
-  //start UDP client and assigning board IP
+void RoveCommEthernet::begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer *TCPServer)
+{
+  // start UDP client and assigning board IP
   UDP.begin(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4);
-  //initializing the TCP server with the correct port
+  // initializing the TCP server with the correct port
   TCP.begin(TCPServer);
 }
-#elif defined(ARDUINO) && (ARDUINO>100)
+#elif defined(ARDUINO) && (ARDUINO > 100)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void RoveCommEthernet::begin(const uint8_t ip_octet_4, EthernetServer* TCPServer, const uint8_t board_mac)
-{ 
-  //start UDP client and assigning board IP
-  UDP.begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET, ip_octet_4, board_mac);
-  //initializing the TCP server with the correct port
-  TCP.begin(TCPServer);
-}
+// void RoveCommEthernet::begin(const uint8_t ip_octet_4, EthernetServer* TCPServer, const uint8_t board_mac)
+// {
+//   //start UDP client and assigning board IP
+//   UDP.begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET, ip_octet_4, board_mac);
+//   //initializing the TCP server with the correct port
+//   TCP.begin(TCPServer);
+// }
 
-void RoveCommEthernet::begin(const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer* TCPServer, const uint8_t board_mac)
-{ 
-  //start UDP client and assigning board IP
-  UDP.begin(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, board_mac);
-  //initializing the TCP server with the correct port
+void RoveCommEthernet::begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer *TCPServer)
+{
+  // start UDP client and assigning board IP
+  UDP.begin(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4);
+  // initializing the TCP server with the correct port
   TCP.begin(TCPServer);
 }
 #endif
 /////////////////////////////////////////////////////////////////////////////////
-struct rovecomm_packet RoveCommEthernet::read() 
-{ 
-  //checks for TCP packets first, as they should be infrequent and require acks
+struct rovecomm_packet RoveCommEthernet::read()
+{
+  // checks for TCP packets first, as they should be infrequent and require acks
   rovecomm_packet = TCP.read();
-  if(rovecomm_packet.data_id != RC_ROVECOMM_NO_DATA_DATA_ID)
+  if (rovecomm_packet.data_id != RC_ROVECOMM_NO_DATA_DATA_ID)
   {
     return rovecomm_packet;
   }
 
-  //check for UDP packets if no TCP were read
+  // check for UDP packets if no TCP were read
   rovecomm_packet = UDP.read();
-  if(rovecomm_packet.data_id != RC_ROVECOMM_NO_DATA_DATA_ID)
+  if (rovecomm_packet.data_id != RC_ROVECOMM_NO_DATA_DATA_ID)
   {
     return rovecomm_packet;
   }
 
-  //otherwise just return no data
+  // otherwise just return no data
   rovecomm_packet.data_id = RC_ROVECOMM_NO_DATA_DATA_ID;
   rovecomm_packet.data_count = 0;
   return rovecomm_packet;
 }
 
 /////write////////////////////////////////////////////////////////////////////////
-//Single-value write
-//Overloaded for each data type
-//Causes bug when doing:RoveComm.write(SINGLE_VALUE_EXAMPLE_ID, 1, analogRead(A0));
-//void write(const uint16_t data_id, const int     data_count, const int      data);
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint8_t  data)
-{           UDP.write(data_id, data_count, data); }
+// Single-value write
+// Overloaded for each data type
+// Causes bug when doing:RoveComm.write(SINGLE_VALUE_EXAMPLE_ID, 1, analogRead(A0));
+// void write(const uint16_t data_id, const int     data_count, const int      data);
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint8_t data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
 void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint16_t data)
-{           UDP.write(data_id, data_count, data); }
+{
+  UDP.write(data_id, data_count, data);
+}
 
 void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint32_t data)
-{           UDP.write(data_id, data_count, data); }
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int8_t   data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int8_t data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int16_t  data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int16_t data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int32_t  data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int32_t data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const float    data)
-{           UDP.write(data_id, data_count, data); }
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const double  data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const float data)
+{
+  UDP.write(data_id, data_count, data);
+}
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const double data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const char    data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const char data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-//Array entry write
-//Overloaded for each data type
-void RoveCommEthernet::write(const uint16_t data_id, const int     data_count, const int      *data)
-{           UDP.write(data_id, data_count, data); }
+// Array entry write
+// Overloaded for each data type
+void RoveCommEthernet::write(const uint16_t data_id, const int data_count, const int *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint8_t  *data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint8_t *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
 void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint16_t *data)
-{           UDP.write(data_id, data_count, data); }
+{
+  UDP.write(data_id, data_count, data);
+}
 
 void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const uint32_t *data)
-{           UDP.write(data_id, data_count, data); }
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int8_t   *data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int8_t *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int16_t  *data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int16_t *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int32_t  *data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const int32_t *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const float    *data)
-{           UDP.write(data_id, data_count, data); }
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const double  *data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const float *data)
+{
+  UDP.write(data_id, data_count, data);
+}
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const double *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
-void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const char    *data)
-{           UDP.write(data_id, data_count, data); }
+void RoveCommEthernet::write(const uint16_t data_id, const uint16_t data_count, const char *data)
+{
+  UDP.write(data_id, data_count, data);
+}
 
 /////writeTo///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//Single-value writeTo
-//Overloaded for each data type
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int  data,
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+// Single-value writeTo
+// Overloaded for each data type
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const uint8_t  data,
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const uint16_t data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const uint32_t data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int8_t   data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int16_t  data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const float data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int32_t  data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const double data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const float  data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const char data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const double  data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+// Array entry write
+// Overloaded for each data type
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const char  data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-//Array entry write
-//Overloaded for each data type
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int  *data,
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const uint8_t  *data,
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const uint16_t *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const uint32_t *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int8_t   *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int16_t  *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const float *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const int32_t  *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const double *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const float  *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeTo(const uint16_t data_id, const uint16_t data_count, const char *data,
+                               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const double  *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+// Overloaded writeReliable////////////////////////////////////////////////////////////////////////////////////////////////////
+// Single-value write
+// handles the data->pointer conversion for user
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeTo(const uint16_t data_id,    const uint16_t data_count, const char  *data, 
-              const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
-{           UDP.writeTo(data_id, data_count, data, ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, RC_ROVECOMM_ETHERNET_UDP_PORT); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-//Overloaded writeReliable////////////////////////////////////////////////////////////////////////////////////////////////////
-//Single-value write
-//handles the data->pointer conversion for user
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  int32_t data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const uint32_t data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  int16_t data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const uint16_t data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t data_id, const uint16_t data_count, const   int8_t data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const float data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  uint8_t data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const double data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  float   data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const char data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
+// Array-Entry write///////////////////////////////////
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  double data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  char   data)
-{           TCP.writeReliable(data_id, data_count, data); }
-//Array-Entry write///////////////////////////////////
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  int32_t *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const uint32_t *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  int16_t *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const uint16_t *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t data_id, const uint16_t data_count, const   int8_t *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const float *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  uint8_t *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const double *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}
 
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  float   *data)
-{           TCP.writeReliable(data_id, data_count, data); }
-
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  double *data)
-{           TCP.writeReliable(data_id, data_count, data); }
-
-void RoveCommEthernet::writeReliable(         const uint16_t  data_id, const uint16_t data_count, const  char   *data)
-{           TCP.writeReliable(data_id, data_count, data); }
+void RoveCommEthernet::writeReliable(const uint16_t data_id, const uint16_t data_count, const char *data)
+{
+  TCP.writeReliable(data_id, data_count, data);
+}

--- a/src/RoveCommEthernet/RoveCommEthernet.h
+++ b/src/RoveCommEthernet/RoveCommEthernet.h
@@ -6,7 +6,7 @@
 
 #if defined(ENERGIA)
 #include "Ethernet.h"
-#elif defined(ARDUINO) && (ARDUINO>100)
+#elif defined(ARDUINO) && (ARDUINO > 100)
 #include "NativeEthernet.h"
 #endif
 
@@ -18,156 +18,154 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 class RoveCommEthernet
 {
-  private:
-    uint8_t num_clients = 0;
-    
-  public:
-    RoveCommEthernetTCP   TCP;
-    RoveCommEthernetUdp   UDP;
+private:
+  uint8_t num_clients = 0;
 
-    struct rovecomm_packet rovecomm_packet;
+public:
+  RoveCommEthernetTCP TCP;
+  RoveCommEthernetUdp UDP;
 
-    /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //checks all ongoing connections for incoming packets and returns the first one as a parsed rovecomm packet
-    struct rovecomm_packet read();
+  struct rovecomm_packet rovecomm_packet;
 
-    #if defined(ENERGIA)
-    /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //Overloaded begin
-    //Default ip address = 192.168.1.XXX
-    //This TCP server will be configured with an IP and port from the RoveComm manifest and allow other boards and base-station
-    //to securely communicate with it
-    void begin(const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer* TCPServer);
-    void begin(const uint8_t ip_octet_4, EthernetServer* TCPServer);
+  /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // checks all ongoing connections for incoming packets and returns the first one as a parsed rovecomm packet
+  struct rovecomm_packet read();
 
-    #elif defined(ARDUINO) && (ARDUINO>100)
-    /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //Overloaded begin
-    //Default ip address = 192.168.1.XXX
-    //This TCP server will be configured with an IP and port from the RoveComm manifest and allow other boards and base-station
-    //to securely communicate with it
-    void begin(const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer* TCPServer, const uint8_t board_mac);
-    void begin(const uint8_t ip_octet_4, EthernetServer* TCPServer, const uint8_t board_mac);
-    #endif
+#if defined(ENERGIA)
+  /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Overloaded begin
+  // Default ip address = 192.168.1.XXX
+  // This TCP server will be configured with an IP and port from the RoveComm manifest and allow other boards and base-station
+  // to securely communicate with it
+  void begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer *TCPServer);
+  void begin(const uint8_t ip_octet_4, EthernetServer *TCPServer);
 
-    /////write////////////////////////////////////////////////////////////////////////
-    //Single-value write
-    //Overloaded for each data type
-    //void write(const uint16_t data_id, const int     data_count, const int      data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint8_t  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int8_t   data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int16_t  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int32_t  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const float    data);
-    void write(const uint16_t data_id, const uint16_t data_count, const double  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const char    data);
+#elif defined(ARDUINO) && (ARDUINO > 100)
+  /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Overloaded begin
+  // Default ip address = 192.168.1.XXX
+  // This TCP server will be configured with an IP and port from the RoveComm manifest and allow other boards and base-station
+  // to securely communicate with it
+  void begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, EthernetServer *TCPServer);
+  // void begin(const uint8_t ip_octet_4, EthernetServer *TCPServer, const uint8_t board_mac);
+#endif
 
+  /////write////////////////////////////////////////////////////////////////////////
+  // Single-value write
+  // Overloaded for each data type
+  // void write(const uint16_t data_id, const int     data_count, const int      data);
+  void write(const uint16_t data_id, const uint16_t data_count, const uint8_t data);
+  void write(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
+  void write(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
+  void write(const uint16_t data_id, const uint16_t data_count, const int8_t data);
+  void write(const uint16_t data_id, const uint16_t data_count, const int16_t data);
+  void write(const uint16_t data_id, const uint16_t data_count, const int32_t data);
+  void write(const uint16_t data_id, const uint16_t data_count, const float data);
+  void write(const uint16_t data_id, const uint16_t data_count, const double data);
+  void write(const uint16_t data_id, const uint16_t data_count, const char data);
 
-    //Array entry write
-    //Overloaded for each data type
-    void write(const uint16_t data_id, const int     data_count, const int      *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint8_t  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int8_t   *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int16_t  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int32_t  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const float    *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const double  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const char    *data);
+  // Array entry write
+  // Overloaded for each data type
+  void write(const uint16_t data_id, const int data_count, const int *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const uint8_t *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const int8_t *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const int16_t *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const int32_t *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const float *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const double *data);
+  void write(const uint16_t data_id, const uint16_t data_count, const char *data);
 
+  /////writeTo///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Single-value writeTo
+  // Overloaded for each data type
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    /////writeTo///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //Single-value writeTo
-    //Overloaded for each data type
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int  data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint8_t  data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint16_t data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint32_t data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int8_t   data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int16_t  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int32_t  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const float data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const float  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const double data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const double  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const char data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const char  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  // Array entry write
+  // Overloaded for each data type
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    //Array entry write
-    //Overloaded for each data type
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int  *data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint8_t  *data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint16_t *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint32_t *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int8_t   *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int16_t  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int32_t  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-    
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const float  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-    
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const double  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-    
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const char  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const float *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    /////writeReliable/////////////////////////////////////////////////////////////////////////////////////////////////
-    //Single-value writeReliable which ensures delivery
-    //Overloaded for each data type
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t   data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const float    data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const double  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const char    data);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const double *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    //Array entry writeReliable which ensures delivery
-    //Overloaded for each data type
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t   *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const float    *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const double  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const char    *data);
+  void writeTo(const uint16_t data_id, const uint16_t data_count, const char *data,
+               const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+
+  /////writeReliable/////////////////////////////////////////////////////////////////////////////////////////////////
+  // Single-value writeReliable which ensures delivery
+  // Overloaded for each data type
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const float data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const double data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const char data);
+
+  // Array entry writeReliable which ensures delivery
+  // Overloaded for each data type
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const float *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const double *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const char *data);
 };
 
 #endif // RoveCommEthernet_h

--- a/src/RoveCommEthernetTCP/RoveCommEthernetTCP.cpp
+++ b/src/RoveCommEthernetTCP/RoveCommEthernetTCP.cpp
@@ -5,159 +5,195 @@
 #if defined(ENERGIA)
 void RoveCommEthernetTCP::begin(EthernetServer *TServer, IPAddress IP)
 {
-    //Set IP
-    Ethernet.enableActivityLed();
-    Ethernet.enableLinkLed(); 
-    //Set up Ethernet
-    Ethernet.begin(   0, IP);
-    //Set up server, and start listening for clients
-    TCPServer = TServer;
-    TCPServer->begin();
+  // Set IP
+  Ethernet.enableActivityLed();
+  Ethernet.enableLinkLed();
+  // Set up Ethernet
+  Ethernet.begin(0, IP);
+  // Set up server, and start listening for clients
+  TCPServer = TServer;
+  TCPServer->begin();
 }
 
-#elif defined(ARDUINO) && (ARDUINO>100)
-#define MAX_CLIENTS   8
-void RoveCommEthernetTCP::begin(EthernetServer *TServer, IPAddress IP, uint8_t* mac)
+#elif defined(ARDUINO) && (ARDUINO > 100)
+#define MAX_CLIENTS 8
+void RoveCommEthernetTCP::begin(EthernetServer *TServer, IPAddress IP, uint8_t *mac)
 {
-    //Set IP
-    Ethernet.hardwareStatus();
-    Ethernet.linkStatus();
-    //Set up Ethernet
-    Ethernet.begin( mac, IP);
-    //Set up server, and start listening for clients
-    TCPServer = TServer;
-    TCPServer->begin();
+  // Set IP
+  Ethernet.hardwareStatus();
+  Ethernet.linkStatus();
+  // Set up Ethernet
+  Ethernet.begin(mac, IP);
+  // Set up server, and start listening for clients
+  TCPServer = TServer;
+  TCPServer->begin();
 }
-void RoveCommEthernetTCP::begin(EthernetServer *TServer, IPAddress IP, uint8_t mac)
+void RoveCommEthernetTCP::begin(EthernetServer *TServer, IPAddress IP)
 {
-    uint8_t maC[6] = { (uint8_t)RC_ROVECOMM_SUBNET_MAC_FIRST_BYTE, (uint8_t)RC_ROVECOMM_SUBNET_MAC_SECOND_BYTE, 
-                       (uint8_t)RC_ROVECOMM_SUBNET_MAC_THIRD_BYTE, (uint8_t)RC_ROVECOMM_SUBNET_MAC_FOURTH_BYTE, 
-                       (uint8_t)RC_ROVECOMM_SUBNET_MAC_FIFTH_BYTE, mac};
-    //Set IP
-    Ethernet.hardwareStatus();
-    Ethernet.linkStatus();
-    //Set up Ethernet
-    Ethernet.begin( maC, IP);
-    //Set up server, and start listening for clients
-    TCPServer = TServer;
-    TCPServer->begin();
+  uint8_t maC[6] = {(uint8_t)RC_ROVECOMM_SUBNET_MAC_FIRST_BYTE, (uint8_t)RC_ROVECOMM_SUBNET_MAC_SECOND_BYTE,
+                    (uint8_t)IP[0], (uint8_t)IP[1],
+                    (uint8_t)IP[2], IP[3]};
+  // Set IP
+  Ethernet.hardwareStatus();
+  Ethernet.linkStatus();
+  // Set up Ethernet
+  Ethernet.begin(maC, IP);
+  // Set up server, and start listening for clients
+  TCPServer = TServer;
+  TCPServer->begin();
 }
 #endif
 
 void RoveCommEthernetTCP::begin(EthernetServer *TServer)
 {
-    //Set up server, and start listening for clients
-    TCPServer = TServer;
-    TCPServer->begin();
+  // Set up server, and start listening for clients
+  TCPServer = TServer;
+  TCPServer->begin();
 }
 
-struct rovecomm_packet RoveCommEthernetTCP::read() 
-{ 
-  //Create new RoveCommPacket
-  rovecomm_packet packet = { 0 };
+struct rovecomm_packet RoveCommEthernetTCP::read()
+{
+  // Create new RoveCommPacket
+  rovecomm_packet packet = {0};
 
-  //the Ethernet Server class avalaible() function returns clients within its array in a round-robin fashion
-  //however there is no guarantee that the client returned has data to be read, therefore we do a full
-  //circuit of the array and stop at the client that has data to be returned.
+  // the Ethernet Server class avalaible() function returns clients within its array in a round-robin fashion
+  // however there is no guarantee that the client returned has data to be read, therefore we do a full
+  // circuit of the array and stop at the client that has data to be returned.
 
-  for(uint8_t i = 0; i < MAX_CLIENTS; i++) 
+  for (uint8_t i = 0; i < MAX_CLIENTS; i++)
   {
     EthernetClient client = TCPServer->available();
 
-    if(client.available() > 0) 
+    if (client.available() > 0)
     {
       packet = roveware::unpackPacket(client);
       return packet;
     }
   }
-  
-  //return an empty packet
+
+  // return an empty packet
   packet.data_id = RC_ROVECOMM_NO_DATA_DATA_ID;
   packet.data_count = 0;
   return packet;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void RoveCommEthernetTCP::_writeReliable(const uint8_t data_type_length, const roveware::data_type_t data_type, const uint16_t data_id, const uint16_t data_count, const void* data)
-{ 
-  //Creat packed udp packet
+void RoveCommEthernetTCP::_writeReliable(const uint8_t data_type_length, const roveware::data_type_t data_type, const uint16_t data_id, const uint16_t data_count, const void *data)
+{
+  // Creat packed udp packet
   struct roveware::_packet _packet = roveware::packPacket(data_id, data_count, data_type, data);
 
-  //write to all available clients
-  TCPServer->write( _packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count))); 
+  // write to all available clients
+  TCPServer->write(_packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count)));
 }
 
-//Overloaded writeReliable////////////////////////////////////////////////////////////////////////////////////////////////////
-//Single-value write
-//handles the data->pointer conversion for user
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  int32_t data )
-{                  int32_t data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  4,  roveware::INT32_T, data_id,               data_count,        (void*) data_p ); }
+// Overloaded writeReliable////////////////////////////////////////////////////////////////////////////////////////////////////
+// Single-value write
+// handles the data->pointer conversion for user
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t data)
+{
+  int32_t data_p[1];
+  data_p[0] = data;
+  _writeReliable(4, roveware::INT32_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const uint32_t data )
-{                  uint32_t data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  4, roveware::UINT32_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t data)
+{
+  uint32_t data_p[1];
+  data_p[0] = data;
+  _writeReliable(4, roveware::UINT32_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  int16_t data )
-{                  int16_t data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  2,  roveware::INT16_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t data)
+{
+  int16_t data_p[1];
+  data_p[0] = data;
+  _writeReliable(2, roveware::INT16_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const uint16_t data )
-{                  uint16_t data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  2, roveware::UINT16_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t data)
+{
+  uint16_t data_p[1];
+  data_p[0] = data;
+  _writeReliable(2, roveware::UINT16_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(         const uint16_t data_id, const uint16_t data_count, const   int8_t data )
-{                  int8_t data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  1,   roveware::INT8_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t data)
+{
+  int8_t data_p[1];
+  data_p[0] = data;
+  _writeReliable(1, roveware::INT8_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  uint8_t data )
-{                  uint8_t data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  1,  roveware::UINT8_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t data)
+{
+  uint8_t data_p[1];
+  data_p[0] = data;
+  _writeReliable(1, roveware::UINT8_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  float data )
-{                  float data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  4,  roveware::FLOAT, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const float data)
+{
+  float data_p[1];
+  data_p[0] = data;
+  _writeReliable(4, roveware::FLOAT, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  double data )
-{                  double data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  8,  roveware::DOUBLE, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const double data)
+{
+  double data_p[1];
+  data_p[0] = data;
+  _writeReliable(8, roveware::DOUBLE, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  char data )
-{                  char data_p[1];
-                   data_p[0] = data;
-                   _writeReliable(  1,  roveware::CHAR, data_id,               data_count,        (void*) data_p ); }
-//Array-Entry write///////////////////////////////////
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  int32_t *data )
-{                  _writeReliable(  4,  roveware::INT32_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const char data)
+{
+  char data_p[1];
+  data_p[0] = data;
+  _writeReliable(1, roveware::CHAR, data_id, data_count, (void *)data_p);
+}
+// Array-Entry write///////////////////////////////////
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t *data)
+{
+  _writeReliable(4, roveware::INT32_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const uint32_t *data )
-{                  _writeReliable(  4, roveware::UINT32_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t *data)
+{
+  _writeReliable(4, roveware::UINT32_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  int16_t *data )
-{                  _writeReliable(  2,  roveware::INT16_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t *data)
+{
+  _writeReliable(2, roveware::INT16_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const uint16_t *data )
-{                  _writeReliable(  2, roveware::UINT16_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t *data)
+{
+  _writeReliable(2, roveware::UINT16_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t data_id, const uint16_t data_count, const   int8_t *data )
-{                  _writeReliable(  1,   roveware::INT8_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t *data)
+{
+  _writeReliable(1, roveware::INT8_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  uint8_t *data )
-{                  _writeReliable(  1,  roveware::UINT8_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t *data)
+{
+  _writeReliable(1, roveware::UINT8_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  float *data )
-{                  _writeReliable(  4,  roveware::FLOAT, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const float *data)
+{
+  _writeReliable(4, roveware::FLOAT, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  double *data )
-{                  _writeReliable(  8,  roveware::DOUBLE, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const double *data)
+{
+  _writeReliable(8, roveware::DOUBLE, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetTCP::writeReliable(        const uint16_t  data_id, const uint16_t data_count, const  char *data )
-{                  _writeReliable(  1,  roveware::CHAR, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetTCP::writeReliable(const uint16_t data_id, const uint16_t data_count, const char *data)
+{
+  _writeReliable(1, roveware::CHAR, data_id, data_count, (void *)data);
+}

--- a/src/RoveCommEthernetTCP/RoveCommEthernetTCP.h
+++ b/src/RoveCommEthernetTCP/RoveCommEthernetTCP.h
@@ -6,7 +6,7 @@
 
 #if defined(ENERGIA)
 #include <Ethernet.h>
-#elif defined(ARDUINO) && (ARDUINO>100)
+#elif defined(ARDUINO) && (ARDUINO > 100)
 #include <NativeEthernet.h>
 #endif
 
@@ -16,51 +16,51 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 class RoveCommEthernetTCP
 {
-  public:
-    EthernetServer *TCPServer;
+public:
+  EthernetServer *TCPServer;
 
-    /////begin////////////////////////////////////////////////////////////////////////
-    #if defined(ENERGIA)
-    void begin(EthernetServer *TServer, IPAddress IP);
-    #elif defined(ARDUINO) && (ARDUINO>100)
-    void begin(EthernetServer *TServer, IPAddress IP, uint8_t* mac);
-    void begin(EthernetServer *TServer, IPAddress IP, uint8_t mac);
-    #endif
-    void begin(EthernetServer *TServer);
+/////begin////////////////////////////////////////////////////////////////////////
+#if defined(ENERGIA)
+  void begin(EthernetServer *TServer, IPAddress IP);
+#elif defined(ARDUINO) && (ARDUINO > 100)
+  void begin(EthernetServer *TServer, IPAddress IP, uint8_t *mac);
+  void begin(EthernetServer *TServer, IPAddress IP);
+#endif
+  void begin(EthernetServer *TServer);
 
-    /////read////////////////////////////////////////////////////////////////////////
-    struct rovecomm_packet read();
+  /////read////////////////////////////////////////////////////////////////////////
+  struct rovecomm_packet read();
 
-    /////writeReliable////////////////////////////////////////////////////////////////////////
-    //Single-value writeReliable which ensures delivery
-    //Overloaded for each data type
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t   data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const float    data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const double  data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const char    data);
+  /////writeReliable////////////////////////////////////////////////////////////////////////
+  // Single-value writeReliable which ensures delivery
+  // Overloaded for each data type
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const float data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const double data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const char data);
 
-    //Array entry writeReliable which ensures delivery
-    //Overloaded for each data type
-    void writeReliable(const uint16_t data_id, const int     data_count, const int      *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t   *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const float    *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const double  *data);
-    void writeReliable(const uint16_t data_id, const uint16_t data_count, const char    *data);
-  private:
-    //Called by overloaded writeReliable functions
-    void _writeReliable(const uint8_t  data_type_length, const roveware::data_type_t data_type, 
-                        const uint16_t data_id, const uint16_t data_count, const void* data);
+  // Array entry writeReliable which ensures delivery
+  // Overloaded for each data type
+  void writeReliable(const uint16_t data_id, const int data_count, const int *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint8_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int8_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int16_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const int32_t *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const float *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const double *data);
+  void writeReliable(const uint16_t data_id, const uint16_t data_count, const char *data);
 
+private:
+  // Called by overloaded writeReliable functions
+  void _writeReliable(const uint8_t data_type_length, const roveware::data_type_t data_type,
+                      const uint16_t data_id, const uint16_t data_count, const void *data);
 };
 
 #endif // RoveCommEthernetTCP_h

--- a/src/RoveCommEthernetUDP/RoveCommEthernetUdp.cpp
+++ b/src/RoveCommEthernetUDP/RoveCommEthernetUdp.cpp
@@ -3,366 +3,444 @@
 
 #if defined(ENERGIA)
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-EthernetUDP        EthernetUdp; 
-IPAddress RoveComm_EthernetUdpSubscriberIps[ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS] = { INADDR_NONE };
+EthernetUDP EthernetUdp;
+IPAddress RoveComm_EthernetUdpSubscriberIps[ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS] = {INADDR_NONE};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void RoveCommEthernetUdp::begin(const int board_ip_octet) 
+void RoveCommEthernetUdp::begin(const int board_ip_octet)
 {
-  //begin using default IP Address
-  this->begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET, 
-             (uint8_t)board_ip_octet);
+  // begin using default IP Address
+  this->begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET,
+              (uint8_t)board_ip_octet);
 }
 
 void RoveCommEthernetUdp::begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4)
-{ 
-  //Set IP
+{
+  // Set IP
   IPAddress LocalIp(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4);
 
   Ethernet.enableActivityLed();
-  Ethernet.enableLinkLed(); 
-  //Set up Ethernet Udp
-  Ethernet.begin(   0, LocalIp);
-  EthernetUdp.begin(RC_ROVECOMM_ETHERNET_UDP_PORT); 
+  Ethernet.enableLinkLed();
+  // Set up Ethernet Udp
+  Ethernet.begin(0, LocalIp);
+  EthernetUdp.begin(RC_ROVECOMM_ETHERNET_UDP_PORT);
   delay(1);
 }
 
-#elif defined(ARDUINO) && (ARDUINO>100)
+#elif defined(ARDUINO) && (ARDUINO > 100)
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-EthernetUDP        EthernetUdp; 
-IPAddress RoveComm_EthernetUdpSubscriberIps[ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS] = { INADDR_NONE };
-void RoveCommEthernetUdp::begin(const int board_ip_octet, const uint8_t board_mac) 
-{
-  //begin using default IP Address
-  this->begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET, 
-             (uint8_t)board_ip_octet, board_mac);
-}
+EthernetUDP EthernetUdp;
+IPAddress RoveComm_EthernetUdpSubscriberIps[ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS] = {INADDR_NONE};
+// void RoveCommEthernetUdp::begin(const int board_ip_octet, const uint8_t board_mac)
+// {
+//   // begin using default IP Address
+//   this->begin(RC_ROVECOMM_SUBNET_IP_FIRST_OCTET, RC_ROVECOMM_SUBNET_IP_SECOND_OCTET, RC_ROVECOMM_SUBNET_IP_THIRD_OCTET,
+//               (uint8_t)board_ip_octet, board_mac);
+// }
 
-void RoveCommEthernetUdp::begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint8_t board_mac)
-{ 
-  //Set IP
+void RoveCommEthernetUdp::begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4)
+{
+  // Set IP
   IPAddress LocalIp(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4);
-  uint8_t mac[6] = { (uint8_t)RC_ROVECOMM_SUBNET_MAC_FIRST_BYTE, (uint8_t)RC_ROVECOMM_SUBNET_MAC_SECOND_BYTE, 
-                     (uint8_t)RC_ROVECOMM_SUBNET_MAC_THIRD_BYTE, (uint8_t)RC_ROVECOMM_SUBNET_MAC_FOURTH_BYTE, 
-                     (uint8_t)RC_ROVECOMM_SUBNET_MAC_FIFTH_BYTE, board_mac};
+  IPAddress subnet(255, 255, 0, 0);
+  uint8_t mac[6] = {(uint8_t)RC_ROVECOMM_SUBNET_MAC_FIRST_BYTE, (uint8_t)RC_ROVECOMM_SUBNET_MAC_SECOND_BYTE,
+                    (uint8_t)ip_octet_1, (uint8_t)ip_octet_2,
+                    (uint8_t)ip_octet_3, ip_octet_4};
 
   Ethernet.hardwareStatus();
   Ethernet.linkStatus();
-  //Set up Ethernet Udp
+  // Set up Ethernet Udp
   Ethernet.begin(mac, LocalIp);
-  EthernetUdp.begin(RC_ROVECOMM_ETHERNET_UDP_PORT); 
+  Ethernet.setSubnetMask(subnet);
+  EthernetUdp.begin(RC_ROVECOMM_ETHERNET_UDP_PORT);
   delay(1);
 }
 #endif
 
-void RoveCommEthernetUdp::begin() 
+void RoveCommEthernetUdp::begin()
 {
-  //Set up Ethernet UDP
-  EthernetUdp.begin(RC_ROVECOMM_ETHERNET_UDP_PORT); 
+  // Set up Ethernet UDP
+  EthernetUdp.begin(RC_ROVECOMM_ETHERNET_UDP_PORT);
 }
 
 /////////////////////////////////////////////////////////////////////////////////
-struct rovecomm_packet RoveCommEthernetUdp::read() 
-{ 
-  //Create new RoveCommPacket
-  struct rovecomm_packet rovecomm_packet = { 0 };
+struct rovecomm_packet RoveCommEthernetUdp::read()
+{
+  // Create new RoveCommPacket
+  struct rovecomm_packet rovecomm_packet = {0};
 
-  //default to empty packet  
-  rovecomm_packet.data_id    =  RC_ROVECOMM_NO_DATA_DATA_ID;
-  rovecomm_packet.data_count =  0;
-   
+  // default to empty packet
+  rovecomm_packet.data_id = RC_ROVECOMM_NO_DATA_DATA_ID;
+  rovecomm_packet.data_count = 0;
+
   int packet_size = EthernetUdp.parsePacket();
   if (packet_size > 0)
-  {       
-	//Create arreay to take packet
-    uint8_t _packet[ packet_size];
+  {
+    // Create arreay to take packet
+    uint8_t _packet[packet_size];
 
-	//Read packet and get IP
+    // Read packet and get IP
     EthernetUdp.read(_packet, packet_size);
     IPAddress ReadFromIp = EthernetUdp.remoteIP();
 
-	//Unpack RoveComm Packet
-    rovecomm_packet = roveware::unpackPacket(_packet); 
-    
-	//Parse special data_ids/////////////////////////////////////////////////////////
-	//Subscribe Request
+    // Unpack RoveComm Packet
+    rovecomm_packet = roveware::unpackPacket(_packet);
+
+    // Parse special data_ids/////////////////////////////////////////////////////////
+    // Subscribe Request
     if (rovecomm_packet.data_id == RC_ROVECOMM_SUBSCRIBE_DATA_ID)
     {
-      for (int i=0; i < ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS; i++) 
+      for (int i = 0; i < ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS; i++)
       {
-		//Break if already subscribed
-        if (RoveComm_EthernetUdpSubscriberIps[i] == ReadFromIp) 
-        {
-          break;
-        } 
-		//Add if not subscribed
-		else if (RoveComm_EthernetUdpSubscriberIps[i] == INADDR_NONE) 
-        {
-          RoveComm_EthernetUdpSubscriberIps[i]  = ReadFromIp;
-          break;
-        }
-      }
-    } 
-	//Unsubscribe Request
-	else if (rovecomm_packet.data_id == RC_ROVECOMM_UNSUBSCRIBE_DATA_ID)
-    {
-      for (int i=0; i < ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS; i++)
-      {
-		//Remove from subscriber list
+        // Break if already subscribed
         if (RoveComm_EthernetUdpSubscriberIps[i] == ReadFromIp)
         {
-          RoveComm_EthernetUdpSubscriberIps[i]  = INADDR_NONE; // remove subscriber
+          break;
+        }
+        // Add if not subscribed
+        else if (RoveComm_EthernetUdpSubscriberIps[i] == INADDR_NONE)
+        {
+          RoveComm_EthernetUdpSubscriberIps[i] = ReadFromIp;
+          break;
         }
       }
-    }  
-  else if (rovecomm_packet.data_id == RC_ROVECOMM_PING_DATA_ID)
+    }
+    // Unsubscribe Request
+    else if (rovecomm_packet.data_id == RC_ROVECOMM_UNSUBSCRIBE_DATA_ID)
+    {
+      for (int i = 0; i < ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS; i++)
+      {
+        // Remove from subscriber list
+        if (RoveComm_EthernetUdpSubscriberIps[i] == ReadFromIp)
+        {
+          RoveComm_EthernetUdpSubscriberIps[i] = INADDR_NONE; // remove subscriber
+        }
+      }
+    }
+    else if (rovecomm_packet.data_id == RC_ROVECOMM_PING_DATA_ID)
     {
       uint8_t data_p[1];
       data_p[0] = 1;
-      this->_writeTo( 1,  roveware::UINT8_T, RC_ROVECOMM_PING_REPLY_DATA_ID, 1, (void*) data_p, ReadFromIp, RC_ROVECOMM_ETHERNET_UDP_PORT);
-    }  
+      this->_writeTo(1, roveware::UINT8_T, RC_ROVECOMM_PING_REPLY_DATA_ID, 1, (void *)data_p, ReadFromIp, RC_ROVECOMM_ETHERNET_UDP_PORT);
+    }
   }
-  //return the packet
+  // return the packet
   return rovecomm_packet;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void RoveCommEthernetUdp::_write(const uint8_t data_type_length, const roveware::data_type_t data_type, const uint16_t data_id, const uint16_t data_count, const void* data)
-{ 
-  //Creat packed udp packet
+void RoveCommEthernetUdp::_write(const uint8_t data_type_length, const roveware::data_type_t data_type, const uint16_t data_id, const uint16_t data_count, const void *data)
+{
+  // Creat packed udp packet
   struct roveware::_packet _packet = roveware::packPacket(data_id, data_count, data_type, data);
-  //Send packet to everyone in subscribers
-  for (int i=0; i < ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS; i++)
+  // Send packet to everyone in subscribers
+  for (int i = 0; i < ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS; i++)
   {
     if (!(RoveComm_EthernetUdpSubscriberIps[i] == INADDR_NONE))
-    {       
+    {
       EthernetUdp.beginPacket(RoveComm_EthernetUdpSubscriberIps[i], RC_ROVECOMM_ETHERNET_UDP_PORT);
-      EthernetUdp.write(      _packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count))); 
+      EthernetUdp.write(_packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count)));
       EthernetUdp.endPacket();
     }
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void RoveCommEthernetUdp::_writeTo(const uint8_t data_type_length, const roveware::data_type_t data_type, const uint16_t data_id, const uint16_t data_count, const void* data,
-                                   const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port) 
-{ 
-  //create packed udp packet
-  struct roveware::_packet _packet = roveware::packPacket(data_id, data_count, data_type, data);
-  
-  //Set up IP
-  IPAddress WriteToIp(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4);
-  
-  //Write to that IP
-  EthernetUdp.beginPacket(WriteToIp, port);
-  EthernetUdp.write(      _packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count)));
-  EthernetUdp.endPacket(); 
-}
-
-void RoveCommEthernetUdp::_writeTo(const uint8_t  data_type_length, const roveware::data_type_t data_type,
-                  const uint16_t data_id,    const uint16_t data_count, const void* data,
-                  IPAddress ipaddress, const uint16_t port)
+void RoveCommEthernetUdp::_writeTo(const uint8_t data_type_length, const roveware::data_type_t data_type, const uint16_t data_id, const uint16_t data_count, const void *data,
+                                   const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
 {
-  //create packed udp packet
+  // create packed udp packet
   struct roveware::_packet _packet = roveware::packPacket(data_id, data_count, data_type, data);
-  
-  //Write to that IP
-  EthernetUdp.beginPacket(ipaddress, port);
-  EthernetUdp.write(      _packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count)));
-  EthernetUdp.endPacket(); 
+
+  // Set up IP
+  IPAddress WriteToIp(ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4);
+
+  // Write to that IP
+  EthernetUdp.beginPacket(WriteToIp, port);
+  EthernetUdp.write(_packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count)));
+  EthernetUdp.endPacket();
 }
-//Overloaded write////////////////////////////////////////////////////////////////////////////////////////////////////
-//Single-value write
-//handles the data->pointer conversion for user
-//void RoveCommEthernetUdp::write(        const  uint16_t      data_id, const  int    data_count, const  int     data ) 
+
+void RoveCommEthernetUdp::_writeTo(const uint8_t data_type_length, const roveware::data_type_t data_type,
+                                   const uint16_t data_id, const uint16_t data_count, const void *data,
+                                   IPAddress ipaddress, const uint16_t port)
+{
+  // create packed udp packet
+  struct roveware::_packet _packet = roveware::packPacket(data_id, data_count, data_type, data);
+
+  // Write to that IP
+  EthernetUdp.beginPacket(ipaddress, port);
+  EthernetUdp.write(_packet.bytes, (ROVECOMM_PACKET_HEADER_SIZE + (data_type_length * data_count)));
+  EthernetUdp.endPacket();
+}
+// Overloaded write////////////////////////////////////////////////////////////////////////////////////////////////////
+// Single-value write
+// handles the data->pointer conversion for user
+// void RoveCommEthernetUdp::write(        const  uint16_t      data_id, const  int    data_count, const  int     data )
 //{                  int data_p[1];
-//                   data_p[0] = data;
-//                   this->_write( 4,  roveware::INT32_T, data_id,               data_count,        (void*) data_p ); }
+//                    data_p[0] = data;
+//                    this->_write( 4,  roveware::INT32_T, data_id,               data_count,        (void*) data_p ); }
 //
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  int32_t data )
-{                  int32_t data_p[1];
-                   data_p[0] = data;
-                   this->_write( 4,  roveware::INT32_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const int32_t data)
+{
+  int32_t data_p[1];
+  data_p[0] = data;
+  this->_write(4, roveware::INT32_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const uint32_t data )
-{                  uint32_t data_p[1];
-                   data_p[0] = data;
-                   this->_write( 4, roveware::UINT32_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const uint32_t data)
+{
+  uint32_t data_p[1];
+  data_p[0] = data;
+  this->_write(4, roveware::UINT32_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  int16_t data )
-{                  int16_t data_p[1];
-                   data_p[0] = data;
-                   this->_write( 2,  roveware::INT16_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const int16_t data)
+{
+  int16_t data_p[1];
+  data_p[0] = data;
+  this->_write(2, roveware::INT16_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const uint16_t data )
-{                  uint16_t data_p[1];
-                   data_p[0] = data;
-                   this->_write( 2, roveware::UINT16_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const uint16_t data)
+{
+  uint16_t data_p[1];
+  data_p[0] = data;
+  this->_write(2, roveware::UINT16_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetUdp::write(         const uint16_t data_id, const uint16_t data_count, const   int8_t data )
-{                  int8_t data_p[1];
-                   data_p[0] = data;
-                   this->_write( 1,   roveware::INT8_T, data_id,               data_count,        (void*) data_p ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const int8_t data)
+{
+  int8_t data_p[1];
+  data_p[0] = data;
+  this->_write(1, roveware::INT8_T, data_id, data_count, (void *)data_p);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  uint8_t data )
-{                  uint8_t data_p[1];
-                   data_p[0] = data;
-                   this->_write( 1,  roveware::UINT8_T, data_id,               data_count,        (void*) data_p ); }
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  float data )
-{                  float data_p[1];
-                   data_p[0] = data;
-                   this->_write( 4,  roveware::FLOAT, data_id,               data_count,        (void*) data_p ); }
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  double data )
-{                  double data_p[1];
-                   data_p[0] = data;
-                   this->_write( 8,  roveware::DOUBLE, data_id,               data_count,        (void*) data_p ); }
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  char data )
-{                  char data_p[1];
-                   data_p[0] = data;
-                   this->_write( 1,  roveware::CHAR, data_id,               data_count,        (void*) data_p ); }                   
-//Array-Entry write///////////////////////////////////
-//void RoveCommEthernetUdp::write(        const  int      data_id, const  int    data_count, const  int     *data ) 
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const uint8_t data)
+{
+  uint8_t data_p[1];
+  data_p[0] = data;
+  this->_write(1, roveware::UINT8_T, data_id, data_count, (void *)data_p);
+}
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const float data)
+{
+  float data_p[1];
+  data_p[0] = data;
+  this->_write(4, roveware::FLOAT, data_id, data_count, (void *)data_p);
+}
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const double data)
+{
+  double data_p[1];
+  data_p[0] = data;
+  this->_write(8, roveware::DOUBLE, data_id, data_count, (void *)data_p);
+}
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const char data)
+{
+  char data_p[1];
+  data_p[0] = data;
+  this->_write(1, roveware::CHAR, data_id, data_count, (void *)data_p);
+}
+// Array-Entry write///////////////////////////////////
+// void RoveCommEthernetUdp::write(        const  int      data_id, const  int    data_count, const  int     *data )
 //{                  this->_write( 4,  roveware::INT32_T, data_id,               data_count,        (void*) data ); }
 //
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  int32_t *data )
-{                  this->_write( 4,  roveware::INT32_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const int32_t *data)
+{
+  this->_write(4, roveware::INT32_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const uint32_t *data )
-{                  this->_write( 4, roveware::UINT32_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const uint32_t *data)
+{
+  this->_write(4, roveware::UINT32_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  int16_t *data )
-{                  this->_write( 2,  roveware::INT16_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const int16_t *data)
+{
+  this->_write(2, roveware::INT16_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const uint16_t *data )
-{                  this->_write( 2, roveware::UINT16_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const uint16_t *data)
+{
+  this->_write(2, roveware::UINT16_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(         const uint16_t data_id, const uint16_t data_count, const   int8_t *data )
-{                  this->_write( 1,   roveware::INT8_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const int8_t *data)
+{
+  this->_write(1, roveware::INT8_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  uint8_t *data )
-{                  this->_write( 1,  roveware::UINT8_T, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const uint8_t *data)
+{
+  this->_write(1, roveware::UINT8_T, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  float *data )
-{                  this->_write( 4,  roveware::FLOAT, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const float *data)
+{
+  this->_write(4, roveware::FLOAT, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(         const uint16_t data_id, const uint16_t data_count, const   double *data )
-{                  this->_write( 8,   roveware::DOUBLE, data_id,               data_count,        (void*) data ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const double *data)
+{
+  this->_write(8, roveware::DOUBLE, data_id, data_count, (void *)data);
+}
 
-void RoveCommEthernetUdp::write(        const uint16_t  data_id, const uint16_t data_count, const  char *data )
-{                  this->_write( 1,  roveware::CHAR, data_id,               data_count,        (void*) data ); }
-//Overloaded writeTo//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//Single-value writeTo
-//handles the data->pointer conversion for user
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  int data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 4,  roveware::INT32_T, data_id,                  data_count,       (void*) data_p,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int32_t data, //handling data->pointer conversion for user
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  int32_t data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 4,  roveware::INT32_T, data_id,                  data_count,       (void*) data_p,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const uint32_t data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t  ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  uint32_t data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 4, roveware::UINT32_T, data_id,                  data_count,        (void*) data_p,
-                                                          ip_octet_1, ip_octet_2,   ip_octet_3,ip_octet_4, port ); }
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int16_t data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  int16_t data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 2,  roveware::INT16_T, data_id,                 data_count,        (void*) data_p,
-                                                          ip_octet_1, ip_octet_2,  ip_octet_3,  ip_octet_4,   port ); }
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const uint16_t data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t  ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  uint16_t data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 2, roveware::UINT16_T, data_id,                  data_count,        (void*) data_p,
-                                                          ip_octet_1, ip_octet_2,   ip_octet_3, ip_octet_4,    port ); }
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int8_t  data, 
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  int8_t data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 1,  roveware::INT8_T,  data_id,                  data_count,       (void*) data_p, 
-                                                          ip_octet_1, ip_octet_2,   ip_octet_3, ip_octet_4,   port ); }
+void RoveCommEthernetUdp::write(const uint16_t data_id, const uint16_t data_count, const char *data)
+{
+  this->_write(1, roveware::CHAR, data_id, data_count, (void *)data);
+}
+// Overloaded writeTo//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Single-value writeTo
+// handles the data->pointer conversion for user
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  int data_p[1];
+  data_p[0] = data;
+  this->_writeTo(4, roveware::INT32_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t data, // handling data->pointer conversion for user
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  int32_t data_p[1];
+  data_p[0] = data;
+  this->_writeTo(4, roveware::INT32_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  uint32_t data_p[1];
+  data_p[0] = data;
+  this->_writeTo(4, roveware::UINT32_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  int16_t data_p[1];
+  data_p[0] = data;
+  this->_writeTo(2, roveware::INT16_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  uint16_t data_p[1];
+  data_p[0] = data;
+  this->_writeTo(2, roveware::UINT16_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  int8_t data_p[1];
+  data_p[0] = data;
+  this->_writeTo(1, roveware::INT8_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const uint8_t data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  uint8_t data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 1,  roveware::UINT8_T, data_id,                  data_count,       (void*) data_p,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  uint8_t data_p[1];
+  data_p[0] = data;
+  this->_writeTo(1, roveware::UINT8_T, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const float data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  float data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 4,  roveware::FLOAT, data_id,                  data_count,       (void*) data_p,
-                                                        ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const float data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  float data_p[1];
+  data_p[0] = data;
+  this->_writeTo(4, roveware::FLOAT, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const double data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  double data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 1,  roveware::DOUBLE, data_id,                  data_count,       (void*) data_p,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const double data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  double data_p[1];
+  data_p[0] = data;
+  this->_writeTo(1, roveware::DOUBLE, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const char data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  char data_p[1];
-                   data_p[0] = data;
-                   this->_writeTo( 4,  roveware::CHAR, data_id,                  data_count,       (void*) data_p,
-                                                        ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }                                                        
-//Array-entry writeTo
-//handles the data->pointer conversion for user
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int *data, //handling data->pointer conversion for user
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 4,  roveware::INT32_T, data_id,                  data_count,       (void*) data,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int32_t *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 4,  roveware::INT32_T, data_id,                  data_count,       (void*) data,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const char data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  char data_p[1];
+  data_p[0] = data;
+  this->_writeTo(4, roveware::CHAR, data_id, data_count, (void *)data_p,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+// Array-entry writeTo
+// handles the data->pointer conversion for user
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int *data, // handling data->pointer conversion for user
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(4, roveware::INT32_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(4, roveware::INT32_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const uint32_t *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t  ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 4, roveware::UINT32_T, data_id,                  data_count,        (void*) data,
-                                                          ip_octet_1, ip_octet_2,   ip_octet_3,ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(4, roveware::UINT32_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int16_t *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 2,  roveware::INT16_T, data_id,                 data_count,        (void*) data,
-                                                          ip_octet_1, ip_octet_2,  ip_octet_3,  ip_octet_4,   port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(2, roveware::INT16_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const uint16_t *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t  ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 2, roveware::UINT16_T, data_id,                  data_count,        (void*) data,
-                                                          ip_octet_1, ip_octet_2,   ip_octet_3, ip_octet_4,    port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(2, roveware::UINT16_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const int8_t  *data, 
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 1,  roveware::INT8_T,  data_id,                  data_count,       (void*) data, 
-                                                          ip_octet_1, ip_octet_2,   ip_octet_3, ip_octet_4,   port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(1, roveware::INT8_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const uint8_t *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 1,  roveware::UINT8_T, data_id,                  data_count,       (void*) data,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(1, roveware::UINT8_T, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const float *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 4,  roveware::FLOAT, data_id,                  data_count,       (void*) data,
-                                                        ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const float *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(4, roveware::FLOAT, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const double *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 8,  roveware::DOUBLE, data_id,                  data_count,       (void*) data,
-                                                          ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const double *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(8, roveware::DOUBLE, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}
 
-void RoveCommEthernetUdp::writeTo(         const uint16_t data_id,    const uint16_t data_count, const char *data,
-                                           const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port )
-{                  this->_writeTo( 1,  roveware::CHAR, data_id,                  data_count,       (void*) data,
-                                                        ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port ); }                                                        
+void RoveCommEthernetUdp::writeTo(const uint16_t data_id, const uint16_t data_count, const char *data,
+                                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port)
+{
+  this->_writeTo(1, roveware::CHAR, data_id, data_count, (void *)data,
+                 ip_octet_1, ip_octet_2, ip_octet_3, ip_octet_4, port);
+}

--- a/src/RoveCommEthernetUDP/RoveCommEthernetUdp.h
+++ b/src/RoveCommEthernetUDP/RoveCommEthernetUdp.h
@@ -7,7 +7,7 @@
 #if defined(ENERGIA)
 #include <Ethernet.h>
 #include <EthernetUdp.h>
-#elif defined(ARDUINO) && (ARDUINO>100)
+#elif defined(ARDUINO) && (ARDUINO > 100)
 #include <NativeEthernet.h>
 #include <NativeEthernetUdp.h>
 #endif
@@ -18,129 +18,128 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 class RoveCommEthernetUdp
 {
-  public:
-    
+public:
     struct rovecomm_packet read();
 
-    #if defined(ENERGIA)
+#if defined(ENERGIA)
     /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //Overloaded begin
-	//Default ip address = 192.168.1.XXX
-	void begin(const int board_ip_octet);
-	void begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4);
-    #elif defined(ARDUINO) && (ARDUINO>100)
+    // Overloaded begin
+    // Default ip address = 192.168.1.XXX
+    void begin(const int board_ip_octet);
+    void begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4);
+#elif defined(ARDUINO) && (ARDUINO > 100)
     /////begin/////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //Overloaded begin
-	//Default ip address = 192.168.1.XXX
-    //Default MAC address = 222.173.190.168.1.xxx
-	void begin(const int board_ip_octet, const uint8_t board_mac);
-	void begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint8_t board_mac);
-    #endif
+    // Overloaded begin
+    // Default ip address = 192.168.1.XXX
+    // Default MAC address = 222.173.190.168.1.xxx
+    //  void begin(const int board_ip_octet, const uint8_t board_mac);
+    void begin(const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4);
+#endif
     void begin();
 
-	/////write////////////////////////////////////////////////////////////////////////
-	//Single-value write
-	//Overloaded for each data type
-    //Causes bug when doing:RoveComm.write(SINGLE_VALUE_EXAMPLE_ID, 1, analogRead(A0));
-	//void write(const uint16_t data_id, const int     data_count, const int      data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint8_t  data);
+    /////write////////////////////////////////////////////////////////////////////////
+    // Single-value write
+    // Overloaded for each data type
+    // Causes bug when doing:RoveComm.write(SINGLE_VALUE_EXAMPLE_ID, 1, analogRead(A0));
+    // void write(const uint16_t data_id, const int     data_count, const int      data);
+    void write(const uint16_t data_id, const uint16_t data_count, const uint8_t data);
     void write(const uint16_t data_id, const uint16_t data_count, const uint16_t data);
     void write(const uint16_t data_id, const uint16_t data_count, const uint32_t data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int8_t   data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int16_t  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int32_t  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const float    data);
-    void write(const uint16_t data_id, const uint16_t data_count, const double  data);
-    void write(const uint16_t data_id, const uint16_t data_count, const char    data);
+    void write(const uint16_t data_id, const uint16_t data_count, const int8_t data);
+    void write(const uint16_t data_id, const uint16_t data_count, const int16_t data);
+    void write(const uint16_t data_id, const uint16_t data_count, const int32_t data);
+    void write(const uint16_t data_id, const uint16_t data_count, const float data);
+    void write(const uint16_t data_id, const uint16_t data_count, const double data);
+    void write(const uint16_t data_id, const uint16_t data_count, const char data);
 
-    //Array entry write
-	//Overloaded for each data type
-    void write(const uint16_t data_id, const int     data_count, const int      *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const uint8_t  *data);
+    // Array entry write
+    // Overloaded for each data type
+    void write(const uint16_t data_id, const int data_count, const int *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const uint8_t *data);
     void write(const uint16_t data_id, const uint16_t data_count, const uint16_t *data);
     void write(const uint16_t data_id, const uint16_t data_count, const uint32_t *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int8_t   *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int16_t  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const int32_t  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const float    *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const double  *data);
-    void write(const uint16_t data_id, const uint16_t data_count, const char    *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const int8_t *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const int16_t *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const int32_t *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const float *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const double *data);
+    void write(const uint16_t data_id, const uint16_t data_count, const char *data);
 
-	/////writeTo///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //Single-value writeTo
-	//Overloaded for each data type
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int  data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    /////writeTo///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Single-value writeTo
+    // Overloaded for each data type
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint8_t  data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint16_t data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint32_t data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int8_t   data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int16_t  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int32_t  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const float  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const float data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const double  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const double data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const char  data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const char data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    //Array entry write
-	//Overloaded for each data type
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int  *data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    // Array entry write
+    // Overloaded for each data type
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint8_t  *data,
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const uint8_t *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint16_t *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const uint16_t *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const uint32_t *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const uint32_t *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int8_t   *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int8_t *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int16_t  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int16_t *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const int32_t  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-    
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const float  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const int32_t *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
 
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const double  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-    
-    void writeTo(const uint16_t data_id,    const uint16_t data_count, const char  *data, 
-                 const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-   
-  private:
-    //Called by overloaded write functions
-    void _write(  const uint8_t  data_type_length, const roveware::data_type_t data_type, 
-                  const uint16_t data_id,    const uint16_t data_count, const void* data);
-    //Called by overloaded writeTo functions
-    void _writeTo(const uint8_t  data_type_length, const roveware::data_type_t data_type,
-                  const uint16_t data_id,    const uint16_t data_count, const void* data,
-                  const uint8_t  ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
-    void _writeTo(const uint8_t  data_type_length, const roveware::data_type_t data_type,
-                  const uint16_t data_id,    const uint16_t data_count, const void* data,
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const float *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const double *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+
+    void writeTo(const uint16_t data_id, const uint16_t data_count, const char *data,
+                 const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+
+private:
+    // Called by overloaded write functions
+    void _write(const uint8_t data_type_length, const roveware::data_type_t data_type,
+                const uint16_t data_id, const uint16_t data_count, const void *data);
+    // Called by overloaded writeTo functions
+    void _writeTo(const uint8_t data_type_length, const roveware::data_type_t data_type,
+                  const uint16_t data_id, const uint16_t data_count, const void *data,
+                  const uint8_t ip_octet_1, const uint8_t ip_octet_2, const uint8_t ip_octet_3, const uint8_t ip_octet_4, const uint16_t port);
+    void _writeTo(const uint8_t data_type_length, const roveware::data_type_t data_type,
+                  const uint16_t data_id, const uint16_t data_count, const void *data,
                   IPAddress ipaddress, const uint16_t port);
 };
 

--- a/src/RoveCommManifest.h
+++ b/src/RoveCommManifest.h
@@ -4,80 +4,90 @@
 #include <stdint.h>
 #include"RoveCommPacket.h"
 
+#define RC_DRIVEBOARD_FIRSTOCTET                  192       
+#define RC_DRIVEBOARD_SECONDOCTET                 168       
+#define RC_DRIVEBOARD_THIRDOCTET                  1         
 #define RC_DRIVEBOARD_FOURTHOCTET                 134       
-#define RC_ROVECOMM_DRIVEBOARD_PORT               11004     
-#define RC_ROVECOMM_DRIVEBOARD_MAC                134       
 
+#define RC_BMSBOARD_FIRSTOCTET                    192       
+#define RC_BMSBOARD_SECONDOCTET                   168       
+#define RC_BMSBOARD_THIRDOCTET                    1         
 #define RC_BMSBOARD_FOURTHOCTET                   133       
-#define RC_ROVECOMM_BMSBOARD_PORT                 11003     
-#define RC_ROVECOMM_BMSBOARD_MAC                  133       
 
+#define RC_POWERBOARD_FIRSTOCTET                  192       
+#define RC_POWERBOARD_SECONDOCTET                 168       
+#define RC_POWERBOARD_THIRDOCTET                  1         
 #define RC_POWERBOARD_FOURTHOCTET                 132       
-#define RC_ROVECOMM_POWERBOARD_PORT               11002     
-#define RC_ROVECOMM_POWERBOARD_MAC                132       
 
+#define RC_BLACKBOXBOARD_FIRSTOCTET               192       
+#define RC_BLACKBOXBOARD_SECONDOCTET              168       
+#define RC_BLACKBOXBOARD_THIRDOCTET               1         
 #define RC_BLACKBOXBOARD_FOURTHOCTET              146       
-#define RC_ROVECOMM_BLACKBOXBOARD_PORT            11015     
-#define RC_ROVECOMM_BLACKBOXBOARD_MAC             146       
 
+#define RC_NAVBOARD_FIRSTOCTET                    192       
+#define RC_NAVBOARD_SECONDOCTET                   168       
+#define RC_NAVBOARD_THIRDOCTET                    1         
 #define RC_NAVBOARD_FOURTHOCTET                   136       
-#define RC_ROVECOMM_NAVBOARD_PORT                 11006     
-#define RC_ROVECOMM_NAVBOARD_MAC                  136       
 
+#define RC_GIMBALBOARD_FIRSTOCTET                 192       
+#define RC_GIMBALBOARD_SECONDOCTET                168       
+#define RC_GIMBALBOARD_THIRDOCTET                 1         
 #define RC_GIMBALBOARD_FOURTHOCTET                135       
-#define RC_ROVECOMM_GIMBALBOARD_PORT              11005     
-#define RC_ROVECOMM_GIMBALBOARD_MAC               135       
 
+#define RC_MULTIMEDIABOARD_FIRSTOCTET             192       
+#define RC_MULTIMEDIABOARD_SECONDOCTET            168       
+#define RC_MULTIMEDIABOARD_THIRDOCTET             1         
 #define RC_MULTIMEDIABOARD_FOURTHOCTET            140       
-#define RC_ROVECOMM_MULTIMEDIABOARD_PORT          11010     
-#define RC_ROVECOMM_MULTIMEDIABOARD_MAC           140       
 
+#define RC_ARMBOARD_FIRSTOCTET                    192       
+#define RC_ARMBOARD_SECONDOCTET                   168       
+#define RC_ARMBOARD_THIRDOCTET                    1         
 #define RC_ARMBOARD_FOURTHOCTET                   131       
-#define RC_ROVECOMM_ARMBOARD_PORT                 11001     
-#define RC_ROVECOMM_ARMBOARD_MAC                  131       
 
+#define RC_SCIENCEACTUATIONBOARD_FIRSTOCTET       192       
+#define RC_SCIENCEACTUATIONBOARD_SECONDOCTET      168       
+#define RC_SCIENCEACTUATIONBOARD_THIRDOCTET       1         
 #define RC_SCIENCEACTUATIONBOARD_FOURTHOCTET      137       
-#define RC_ROVECOMM_SCIENCEACTUATIONBOARD_PORT    11007     
-#define RC_ROVECOMM_SCIENCEACTUATIONBOARD_MAC     137       
 
+#define RC_SCIENCESENSORSBOARD_FIRSTOCTET         192       
+#define RC_SCIENCESENSORSBOARD_SECONDOCTET        168       
+#define RC_SCIENCESENSORSBOARD_THIRDOCTET         1         
 #define RC_SCIENCESENSORSBOARD_FOURTHOCTET        138       
-#define RC_ROVECOMM_SCIENCESENSORSBOARD_PORT      11008     
-#define RC_ROVECOMM_SCIENCESENSORSBOARD_MAC       138       
 
+#define RC_AUTONOMYBOARD_FIRSTOCTET               192       
+#define RC_AUTONOMYBOARD_SECONDOCTET              168       
+#define RC_AUTONOMYBOARD_THIRDOCTET               1         
 #define RC_AUTONOMYBOARD_FOURTHOCTET              139       
-#define RC_ROVECOMM_AUTONOMYBOARD_PORT            11009     
-#define RC_ROVECOMM_AUTONOMYBOARD_MAC             139       
 
+#define RC_CAMERA1BOARD_FIRSTOCTET                192       
+#define RC_CAMERA1BOARD_SECONDOCTET               168       
+#define RC_CAMERA1BOARD_THIRDOCTET                1         
 #define RC_CAMERA1BOARD_FOURTHOCTET               141       
-#define RC_ROVECOMM_CAMERA1BOARD_PORT             11011     
-#define RC_ROVECOMM_CAMERA1BOARD_MAC              141       
 
+#define RC_CAMERA2BOARD_FIRSTOCTET                192       
+#define RC_CAMERA2BOARD_SECONDOCTET               168       
+#define RC_CAMERA2BOARD_THIRDOCTET                1         
 #define RC_CAMERA2BOARD_FOURTHOCTET               142       
-#define RC_ROVECOMM_CAMERA2BOARD_PORT             11012     
-#define RC_ROVECOMM_CAMERA2BOARD_MAC              142       
 
+#define RC_HEATERBOARD_FIRSTOCTET                 192       
+#define RC_HEATERBOARD_SECONDOCTET                168       
+#define RC_HEATERBOARD_THIRDOCTET                 1         
 #define RC_HEATERBOARD_FOURTHOCTET                144       
-#define RC_ROVECOMM_HEATERBOARD_PORT              11014     
-#define RC_ROVECOMM_HEATERBOARD_MAC               144       
 
+#define RC_SIGNALSTACKBOARD_FIRSTOCTET            192       
+#define RC_SIGNALSTACKBOARD_SECONDOCTET           168       
+#define RC_SIGNALSTACKBOARD_THIRDOCTET            1         
 #define RC_SIGNALSTACKBOARD_FOURTHOCTET           145       
-#define RC_ROVECOMM_SIGNALSTACKBOARD_PORT         11015     
-#define RC_ROVECOMM_SIGNALSTACKBOARD_MAC          145       
 
 
 
 #define ROVECOMM_UPDATE_RATE                      100       
 #define RC_ROVECOMM_ETHERNET_UDP_PORT             11000     
-#define RC_ROVECOMM_SUBNET_IP_FIRST_OCTET         192       
-#define RC_ROVECOMM_SUBNET_IP_SECOND_OCTET        168       
-#define RC_ROVECOMM_SUBNET_IP_THIRD_OCTET         1         
+#define RC_ROVECOMM_ETHERNET_TCP_PORT             12000     
 
 
 #define RC_ROVECOMM_SUBNET_MAC_FIRST_BYTE         222       
 #define RC_ROVECOMM_SUBNET_MAC_SECOND_BYTE        173       
-#define RC_ROVECOMM_SUBNET_MAC_THIRD_BYTE         190       
-#define RC_ROVECOMM_SUBNET_MAC_FOURTH_BYTE        168       
-#define RC_ROVECOMM_SUBNET_MAC_FIFTH_BYTE         1         
 
 
 ///////////////////////////////////////////////////

--- a/src/RoveCommManifest.h
+++ b/src/RoveCommManifest.h
@@ -6,78 +6,78 @@
 
 #define RC_DRIVEBOARD_FIRSTOCTET                  192       
 #define RC_DRIVEBOARD_SECONDOCTET                 168       
-#define RC_DRIVEBOARD_THIRDOCTET                  1         
-#define RC_DRIVEBOARD_FOURTHOCTET                 134       
+#define RC_DRIVEBOARD_THIRDOCTET                  2         
+#define RC_DRIVEBOARD_FOURTHOCTET                 103       
 
 #define RC_BMSBOARD_FIRSTOCTET                    192       
 #define RC_BMSBOARD_SECONDOCTET                   168       
-#define RC_BMSBOARD_THIRDOCTET                    1         
-#define RC_BMSBOARD_FOURTHOCTET                   133       
+#define RC_BMSBOARD_THIRDOCTET                    2         
+#define RC_BMSBOARD_FOURTHOCTET                   100       
 
 #define RC_POWERBOARD_FIRSTOCTET                  192       
 #define RC_POWERBOARD_SECONDOCTET                 168       
-#define RC_POWERBOARD_THIRDOCTET                  1         
-#define RC_POWERBOARD_FOURTHOCTET                 132       
+#define RC_POWERBOARD_THIRDOCTET                  2         
+#define RC_POWERBOARD_FOURTHOCTET                 101       
 
 #define RC_BLACKBOXBOARD_FIRSTOCTET               192       
 #define RC_BLACKBOXBOARD_SECONDOCTET              168       
-#define RC_BLACKBOXBOARD_THIRDOCTET               1         
-#define RC_BLACKBOXBOARD_FOURTHOCTET              146       
+#define RC_BLACKBOXBOARD_THIRDOCTET               2         
+#define RC_BLACKBOXBOARD_FOURTHOCTET              102       
 
 #define RC_NAVBOARD_FIRSTOCTET                    192       
 #define RC_NAVBOARD_SECONDOCTET                   168       
-#define RC_NAVBOARD_THIRDOCTET                    1         
-#define RC_NAVBOARD_FOURTHOCTET                   136       
+#define RC_NAVBOARD_THIRDOCTET                    2         
+#define RC_NAVBOARD_FOURTHOCTET                   104       
 
 #define RC_GIMBALBOARD_FIRSTOCTET                 192       
 #define RC_GIMBALBOARD_SECONDOCTET                168       
-#define RC_GIMBALBOARD_THIRDOCTET                 1         
-#define RC_GIMBALBOARD_FOURTHOCTET                135       
+#define RC_GIMBALBOARD_THIRDOCTET                 2         
+#define RC_GIMBALBOARD_FOURTHOCTET                106       
 
 #define RC_MULTIMEDIABOARD_FIRSTOCTET             192       
 #define RC_MULTIMEDIABOARD_SECONDOCTET            168       
-#define RC_MULTIMEDIABOARD_THIRDOCTET             1         
-#define RC_MULTIMEDIABOARD_FOURTHOCTET            140       
+#define RC_MULTIMEDIABOARD_THIRDOCTET             2         
+#define RC_MULTIMEDIABOARD_FOURTHOCTET            105       
 
 #define RC_ARMBOARD_FIRSTOCTET                    192       
 #define RC_ARMBOARD_SECONDOCTET                   168       
-#define RC_ARMBOARD_THIRDOCTET                    1         
-#define RC_ARMBOARD_FOURTHOCTET                   131       
+#define RC_ARMBOARD_THIRDOCTET                    2         
+#define RC_ARMBOARD_FOURTHOCTET                   107       
 
 #define RC_SCIENCEACTUATIONBOARD_FIRSTOCTET       192       
 #define RC_SCIENCEACTUATIONBOARD_SECONDOCTET      168       
-#define RC_SCIENCEACTUATIONBOARD_THIRDOCTET       1         
-#define RC_SCIENCEACTUATIONBOARD_FOURTHOCTET      137       
+#define RC_SCIENCEACTUATIONBOARD_THIRDOCTET       2         
+#define RC_SCIENCEACTUATIONBOARD_FOURTHOCTET      108       
 
 #define RC_SCIENCESENSORSBOARD_FIRSTOCTET         192       
 #define RC_SCIENCESENSORSBOARD_SECONDOCTET        168       
-#define RC_SCIENCESENSORSBOARD_THIRDOCTET         1         
-#define RC_SCIENCESENSORSBOARD_FOURTHOCTET        138       
+#define RC_SCIENCESENSORSBOARD_THIRDOCTET         3         
+#define RC_SCIENCESENSORSBOARD_FOURTHOCTET        101       
 
 #define RC_AUTONOMYBOARD_FIRSTOCTET               192       
 #define RC_AUTONOMYBOARD_SECONDOCTET              168       
-#define RC_AUTONOMYBOARD_THIRDOCTET               1         
-#define RC_AUTONOMYBOARD_FOURTHOCTET              139       
+#define RC_AUTONOMYBOARD_THIRDOCTET               3         
+#define RC_AUTONOMYBOARD_FOURTHOCTET              100       
 
 #define RC_CAMERA1BOARD_FIRSTOCTET                192       
 #define RC_CAMERA1BOARD_SECONDOCTET               168       
-#define RC_CAMERA1BOARD_THIRDOCTET                1         
-#define RC_CAMERA1BOARD_FOURTHOCTET               141       
+#define RC_CAMERA1BOARD_THIRDOCTET                4         
+#define RC_CAMERA1BOARD_FOURTHOCTET               100       
 
 #define RC_CAMERA2BOARD_FIRSTOCTET                192       
 #define RC_CAMERA2BOARD_SECONDOCTET               168       
-#define RC_CAMERA2BOARD_THIRDOCTET                1         
-#define RC_CAMERA2BOARD_FOURTHOCTET               142       
+#define RC_CAMERA2BOARD_THIRDOCTET                4         
+#define RC_CAMERA2BOARD_FOURTHOCTET               101       
 
 #define RC_HEATERBOARD_FIRSTOCTET                 192       
 #define RC_HEATERBOARD_SECONDOCTET                168       
-#define RC_HEATERBOARD_THIRDOCTET                 1         
-#define RC_HEATERBOARD_FOURTHOCTET                144       
+#define RC_HEATERBOARD_THIRDOCTET                 2         
+#define RC_HEATERBOARD_FOURTHOCTET                109       
 
 #define RC_SIGNALSTACKBOARD_FIRSTOCTET            192       
 #define RC_SIGNALSTACKBOARD_SECONDOCTET           168       
-#define RC_SIGNALSTACKBOARD_THIRDOCTET            1         
-#define RC_SIGNALSTACKBOARD_FOURTHOCTET           145       
+#define RC_SIGNALSTACKBOARD_THIRDOCTET            3         
+#define RC_SIGNALSTACKBOARD_FOURTHOCTET           102       
 
 
 

--- a/src/RoveCommPacket.h
+++ b/src/RoveCommPacket.h
@@ -7,61 +7,72 @@
 
 #if defined(ENERGIA)
 #include <Ethernet.h>
-#elif defined(ARDUINO) && (ARDUINO>100)
+#elif defined(ARDUINO) && (ARDUINO > 100)
 #include <NativeEthernet.h>
 #endif
 
 //////////////////////////////////////////////////////
-#define ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS      10
-#define ROVECOMM_PACKET_MAX_DATA_COUNT        65535
-#define ROVECOMM_PACKET_HEADER_SIZE    6
-#define ROVECOMM_VERSION    25
+#define ROVECOMM_ETHERNET_UDP_MAX_SUBSCRIBERS 10
+#define ROVECOMM_PACKET_MAX_DATA_COUNT 65535
+#define ROVECOMM_PACKET_HEADER_SIZE 6
+#define ROVECOMM_VERSION 3
 
 //////////////////////////////////////////////////////
-//Carrys RoveComm packet data
-//Used to return RoveComm::read() values as a struct
+// Carrys RoveComm packet data
+// Used to return RoveComm::read() values as a struct
 struct rovecomm_packet
 {
   uint16_t data_id;
   uint16_t data_count;
   uint8_t data_type;
-  #if defined(ENERGIA)
-  char data[ROVECOMM_PACKET_MAX_DATA_COUNT/3*sizeof(uint8_t)]; //Tiva can only support 21,000 uint8_t at once due to memory issues
-  #elif defined(ARDUINO) && (ARDUINO>100)
-  char data[ROVECOMM_PACKET_MAX_DATA_COUNT/2*sizeof(uint8_t)];  //Teensy can only support 32,000 uint8_t at once due to memory issues
-  #endif
-};  
+#if defined(ENERGIA)
+  char data[ROVECOMM_PACKET_MAX_DATA_COUNT / 3 * sizeof(uint8_t)]; // Tiva can only support 21,000 uint8_t at once due to memory issues
+#elif defined(ARDUINO) && (ARDUINO > 100)
+  char data[ROVECOMM_PACKET_MAX_DATA_COUNT / 2 * sizeof(uint8_t)];                                     // Teensy can only support 32,000 uint8_t at once due to memory issues
+#endif
+};
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace roveware
 {
-  //DataType RoveComm encoding
-  enum data_type_t { INT8_T=0, UINT8_T=1, INT16_T=2, UINT16_T=3, INT32_T=4, UINT32_T=5, FLOAT=6, DOUBLE=7, CHAR=8};
+  // DataType RoveComm encoding
+  enum data_type_t
+  {
+    INT8_T = 0,
+    UINT8_T = 1,
+    INT16_T = 2,
+    UINT16_T = 3,
+    INT32_T = 4,
+    UINT32_T = 5,
+    FLOAT = 6,
+    DOUBLE = 7,
+    CHAR = 8
+  };
 
   ////////////////////////////////////////////////
   // The RoveComm udp packet header is 6 bytes long:
   // uint8_t  rovecomm_version
-  // uint16_t data_id   
+  // uint16_t data_id
   // uint16_t  data_count
   // uint8_t  data_type
 
-  //Carrys Udp packet data
+  // Carrys Udp packet data
   struct _packet
   {
-    #if defined(ENERGIA)
-    uint8_t bytes[ROVECOMM_PACKET_HEADER_SIZE + sizeof(uint8_t) * ROVECOMM_PACKET_MAX_DATA_COUNT/3];  //Tiva can only support 21,000 uint8_t at once due to memory issues
-    #elif defined(ARDUINO) && (ARDUINO>100)
-    uint8_t bytes[ROVECOMM_PACKET_HEADER_SIZE + sizeof(uint8_t) * ROVECOMM_PACKET_MAX_DATA_COUNT/2];  //Teensy can only support 32,000 uint8_t at once due to memory issues
-    #endif
+#if defined(ENERGIA)
+    uint8_t bytes[ROVECOMM_PACKET_HEADER_SIZE + sizeof(uint8_t) * ROVECOMM_PACKET_MAX_DATA_COUNT / 3]; // Tiva can only support 21,000 uint8_t at once due to memory issues
+#elif defined(ARDUINO) && (ARDUINO > 100)
+    uint8_t bytes[ROVECOMM_PACKET_HEADER_SIZE + sizeof(uint8_t) * ROVECOMM_PACKET_MAX_DATA_COUNT / 2]; // Teensy can only support 32,000 uint8_t at once due to memory issues
+#endif
   };
 
-  struct _packet        packPacket(const uint16_t data_id, const uint16_t data_count, const data_type_t data_type, const void* data);
+  struct _packet packPacket(const uint16_t data_id, const uint16_t data_count, const data_type_t data_type, const void *data);
 
-  //for UDP packets, of known size
-  struct rovecomm_packet unpackPacket(uint8_t  _packet[]);
-  //for TCP, where we read streams of data, with size determined by parsing header
+  // for UDP packets, of known size
+  struct rovecomm_packet unpackPacket(uint8_t _packet[]);
+  // for TCP, where we read streams of data, with size determined by parsing header
   struct rovecomm_packet unpackPacket(EthernetClient client);
 
-}// end namespace/////////////////////////////////////////////////////////////////////////////////////////////////
+} // end namespace/////////////////////////////////////////////////////////////////////////////////////////////////
 
 #endif // ROVECOMM_PACKET_H

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "ManifestFormatVersion": 3,
+  "ManifestSpecVersion": 3,
   "DataTypes": {
     "INT8_T": 0,
     "UINT8_T": 1,
@@ -27,7 +27,7 @@
   "headerLength": 6,
   "RovecommManifest": {
     "Drive": {
-      "Ip": "192.168.1.134",
+      "Ip": "192.168.2.103",
       "Commands": {
         "DriveLeftRight": {
           "dataId": 1000,
@@ -59,7 +59,7 @@
       "Error": {}
     },
     "BMS": {
-      "Ip": "192.168.1.133",
+      "Ip": "192.168.2.100",
       "Commands": {
         "BMSStop": {
           "dataId": 2000,
@@ -122,7 +122,7 @@
       }
     },
     "Power": {
-      "Ip": "192.168.1.132",
+      "Ip": "192.168.2.101",
       "Commands": {
         "MotorBusEnable": {
           "dataId": 3000,
@@ -203,7 +203,7 @@
       }
     },
     "Blackbox": {
-      "Ip": "192.168.1.146",
+      "Ip": "192.168.2.102",
       "Commands": {},
       "Telemetry": {
         "BlackboxListening": {
@@ -216,7 +216,7 @@
       "Error": {}
     },
     "Nav": {
-      "Ip": "192.168.1.136",
+      "Ip": "192.168.2.104",
       "Commands": {},
       "Telemetry": {
         "GPSLatLon": {
@@ -260,7 +260,7 @@
       }
     },
     "Gimbal": {
-      "Ip": "192.168.1.135",
+      "Ip": "192.168.2.106",
       "Commands": {
         "LeftDriveGimbalIncrement": {
           "dataId": 6000,
@@ -297,7 +297,7 @@
       "Error": {}
     },
     "Multimedia": {
-      "Ip": "192.168.1.140",
+      "Ip": "192.168.2.105",
       "Commands": {
         "LEDRGB": {
           "dataId": 7000,
@@ -344,7 +344,7 @@
       }
     },
     "Arm": {
-      "Ip": "192.168.1.131",
+      "Ip": "192.168.2.107",
       "Commands": {
         "ArmVelocityControl": {
           "dataId": 8000,
@@ -473,7 +473,7 @@
       }
     },
     "ScienceActuation": {
-      "Ip": "192.168.1.137",
+      "Ip": "192.168.2.108",
       "Commands": {
         "SensorAxis": {
           "dataId": 9000,
@@ -554,7 +554,7 @@
       }
     },
     "ScienceSensors": {
-      "Ip": "192.168.1.138",
+      "Ip": "192.168.3.101",
       "Commands": {
         "FluorometerLEDs": {
           "dataId": 10000,
@@ -616,7 +616,7 @@
       "Error": {}
     },
     "Autonomy": {
-      "Ip": "192.168.1.139",
+      "Ip": "192.168.3.100",
       "Commands": {
         "StartAutonomy": {
           "dataId": 11000,
@@ -684,7 +684,7 @@
       "Error": {}
     },
     "Camera1": {
-      "Ip": "192.168.1.141",
+      "Ip": "192.168.4.100",
       "Commands": {
         "ChangeCameras": {
           "dataId": 12000,
@@ -717,13 +717,13 @@
       }
     },
     "Camera2": {
-      "Ip": "192.168.1.142",
+      "Ip": "192.168.4.101",
       "Commands": {},
       "Telemetry": {},
       "Error": {}
     },
     "Heater": {
-      "Ip": "192.168.1.144",
+      "Ip": "192.168.2.109",
       "Commands": {
         "HeaterToggle": {
           "dataId": 15000,
@@ -756,7 +756,7 @@
       }
     },
     "SignalStack": {
-      "Ip": "192.168.1.145",
+      "Ip": "192.168.3.102",
       "Commands": {
         "SignalsRotate": {
           "dataId": 16000,
@@ -784,13 +784,13 @@
     }
   },
   "NetworkDevices": {
-    "BasestationSwitch": { "Ip": "192.168.1.80" },
-    "RoverSwitch": { "Ip": "192.168.1.81" },
-    "Rover900MHzRocket": { "Ip": "192.168.1.82" },
-    "Basestation900MHzRocket": { "Ip": "192.168.1.83" },
-    "Rover5GHzRocket": { "Ip": "192.168.1.84" },
-    "Basestation5GHzRocket": { "Ip": "192.168.1.85" },
-    "Rover2_4GHzRocket": { "Ip": "192.168.1.86" },
-    "Basestation2_4GHzRocket": { "Ip": "192.168.1.87"}
+    "BasestationSwitch": { "Ip": "192.168.126.1" },
+    "RoverSwitch": { "Ip": "192.168.126.2" },
+    "Rover900MHzRocket": { "Ip": "192.168.126.11" },
+    "Basestation900MHzRocket": { "Ip": "192.168.126.10" },
+    "Rover5GHzRocket": { "Ip": "192.168.126.31" },
+    "Basestation5GHzRocket": { "Ip": "192.168.126.30" },
+    "Rover2_4GHzRocket": { "Ip": "192.168.126.21" },
+    "Basestation2_4GHzRocket": { "Ip": "192.168.126.20"}
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,4 +1,5 @@
 {
+  "ManifestFormatVersion": 3,
   "DataTypes": {
     "INT8_T": 0,
     "UINT8_T": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,14 +21,12 @@
   },
   "updateRate": 100,
   "ethernetUDPPort": 11000,
-  "subnetIP": [192, 168, 1],
-  "MACaddress": [222, 173, 190, 168, 1],
+  "ethernetTCPPort": 12000,
+  "MACaddressPrefix": [222, 173],
   "headerLength": 6,
   "RovecommManifest": {
     "Drive": {
       "Ip": "192.168.1.134",
-      "Port": 11004,
-      "MAC": "222.173.190.168.1.134",
       "Commands": {
         "DriveLeftRight": {
           "dataId": 1000,
@@ -61,8 +59,6 @@
     },
     "BMS": {
       "Ip": "192.168.1.133",
-      "Port": 11003,
-      "MAC": "222.173.190.168.1.133",
       "Commands": {
         "BMSStop": {
           "dataId": 2000,
@@ -126,8 +122,6 @@
     },
     "Power": {
       "Ip": "192.168.1.132",
-      "Port": 11002,
-      "MAC": "222.173.190.168.1.132",
       "Commands": {
         "MotorBusEnable": {
           "dataId": 3000,
@@ -209,8 +203,6 @@
     },
     "Blackbox": {
       "Ip": "192.168.1.146",
-      "Port": 11015,
-      "MAC": "222.173.190.168.1.146",
       "Commands": {},
       "Telemetry": {
         "BlackboxListening": {
@@ -224,8 +216,6 @@
     },
     "Nav": {
       "Ip": "192.168.1.136",
-      "Port": 11006,
-      "MAC": "222.173.190.168.1.136",
       "Commands": {},
       "Telemetry": {
         "GPSLatLon": {
@@ -270,8 +260,6 @@
     },
     "Gimbal": {
       "Ip": "192.168.1.135",
-      "Port": 11005,
-      "MAC": "222.173.190.168.1.135",
       "Commands": {
         "LeftDriveGimbalIncrement": {
           "dataId": 6000,
@@ -309,8 +297,6 @@
     },
     "Multimedia": {
       "Ip": "192.168.1.140",
-      "Port": 11010,
-      "MAC": "222.173.190.168.1.140",
       "Commands": {
         "LEDRGB": {
           "dataId": 7000,
@@ -358,8 +344,6 @@
     },
     "Arm": {
       "Ip": "192.168.1.131",
-      "Port": 11001,
-      "MAC": "222.173.190.168.1.131",
       "Commands": {
         "ArmVelocityControl": {
           "dataId": 8000,
@@ -489,8 +473,6 @@
     },
     "ScienceActuation": {
       "Ip": "192.168.1.137",
-      "Port": 11007,
-      "MAC": "222.173.190.168.1.137",
       "Commands": {
         "SensorAxis": {
           "dataId": 9000,
@@ -572,8 +554,6 @@
     },
     "ScienceSensors": {
       "Ip": "192.168.1.138",
-      "Port": 11008,
-      "MAC": "222.173.190.168.1.138",
       "Commands": {
         "FluorometerLEDs": {
           "dataId": 10000,
@@ -636,8 +616,6 @@
     },
     "Autonomy": {
       "Ip": "192.168.1.139",
-      "Port": 11009,
-      "MAC": "222.173.190.168.1.139",
       "Commands": {
         "StartAutonomy": {
           "dataId": 11000,
@@ -706,8 +684,6 @@
     },
     "Camera1": {
       "Ip": "192.168.1.141",
-      "Port": 11011,
-      "MAC": "222.173.190.168.1.141",
       "Commands": {
         "ChangeCameras": {
           "dataId": 12000,
@@ -741,16 +717,12 @@
     },
     "Camera2": {
       "Ip": "192.168.1.142",
-      "Port": 11012,
-      "MAC": "222.173.190.168.1.142",
       "Commands": {},
       "Telemetry": {},
       "Error": {}
     },
     "Heater": {
       "Ip": "192.168.1.144",
-      "Port": 11014,
-      "MAC": "222.173.190.168.1.144",
       "Commands": {
         "HeaterToggle": {
           "dataId": 15000,
@@ -784,8 +756,6 @@
     },
     "SignalStack": {
       "Ip": "192.168.1.145",
-      "Port": 11015,
-      "MAC": "222.173.190.168.1.145",
       "Commands": {
         "SignalsRotate": {
           "dataId": 16000,

--- a/src/manifest_parser.py
+++ b/src/manifest_parser.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # Check manifest spec version
     if this.manifest_file["ManifestSpecVersion"] != 3:
         print("Expected Manifest Spec v3, Aborting")
-        return
+        exit()
 
     # Manifest contains additional info not necessary for header file
     this.manifest = this.manifest_file["RovecommManifest"]

--- a/src/manifest_parser.py
+++ b/src/manifest_parser.py
@@ -89,19 +89,22 @@ if __name__ == "__main__":
     # Write all the Ips and Ports together
     for board in this.manifest:
         ip = this.manifest[board]["Ip"]
-        port = this.manifest[board]["Port"]
-        mac = this.manifest[board]["MAC"]
-        fourth_octet = ip.replace("192.168.1.", "")
-        last_byte = mac.replace("222.173.190.168.1.", "")
+        ip_octs = ip.split(".")
 
         # The < character indicates something is left aligned, in this case we are assuming that the name
         # plus #define is less than or equal to 50 characters and the PORT/IP less than 10
         this.header_file.write(
-            f"{define_prefix + ' RC_'+board.upper()+'BOARD'+'_FOURTHOCTET':<50}{fourth_octet:<10}\n"
+            f"{define_prefix + ' RC_'+board.upper()+'BOARD'+'_FIRSTOCTET':<50}{ip_octs[0]:<10}\n"
         )
-        this.header_file.write(f"{define_prefix+' RC_ROVECOMM_'+board.upper()+'BOARD'+'_PORT':<50}{str(port):<10}\n")
-        this.header_file.write(f"{define_prefix+' RC_ROVECOMM_'+board.upper()+'BOARD'+'_MAC':<50}{last_byte:<10}\n")
-
+        this.header_file.write(
+            f"{define_prefix + ' RC_'+board.upper()+'BOARD'+'_SECONDOCTET':<50}{ip_octs[1]:<10}\n"
+        )
+        this.header_file.write(
+            f"{define_prefix + ' RC_'+board.upper()+'BOARD'+'_THIRDOCTET':<50}{ip_octs[2]:<10}\n"
+        )
+        this.header_file.write(
+            f"{define_prefix + ' RC_'+board.upper()+'BOARD'+'_FOURTHOCTET':<50}{ip_octs[3]:<10}\n"
+        )
         this.header_file.write("\n")
 
     # A couple of newlines between IP assignments and rovecomm messages
@@ -112,23 +115,22 @@ if __name__ == "__main__":
     this.header_file.write(f"{define_prefix + ' ROVECOMM_UPDATE_RATE':<50}{this.update_rate:<10}\n")
 
     this.udp_port = this.manifest_file["ethernetUDPPort"]
+    this.tcp_port = this.manifest_file["ethernetTCPPort"]
     this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_ETHERNET_UDP_PORT':<50}{this.udp_port:<10}\n")
+    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_ETHERNET_TCP_PORT':<50}{this.tcp_port:<10}\n")
 
     # Also grab the first 3 octets of the subnet IP
-    this.subnet_ip = this.manifest_file["subnetIP"]
-    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_IP_FIRST_OCTET':<50}{this.subnet_ip[0]:<10}\n")
-    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_IP_SECOND_OCTET':<50}{this.subnet_ip[1]:<10}\n")
-    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_IP_THIRD_OCTET':<50}{this.subnet_ip[2]:<10}\n")
+    # this.subnet_ip = this.manifest_file["subnetIP"]
+    # this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_IP_FIRST_OCTET':<50}{this.subnet_ip[0]:<10}\n")
+    # this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_IP_SECOND_OCTET':<50}{this.subnet_ip[1]:<10}\n")
+    # this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_IP_THIRD_OCTET':<50}{this.subnet_ip[2]:<10}\n")
 
     this.header_file.write("\n\n")
 
     # Grabs the first 5 bytes of the MAC address
-    this.subnet_mac = this.manifest_file["MACaddress"]
+    this.subnet_mac = this.manifest_file["MACaddressPrefix"]
     this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_MAC_FIRST_BYTE':<50}{this.subnet_mac[0]:<10}\n")
     this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_MAC_SECOND_BYTE':<50}{this.subnet_mac[1]:<10}\n")
-    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_MAC_THIRD_BYTE':<50}{this.subnet_mac[2]:<10}\n")
-    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_MAC_FOURTH_BYTE':<50}{this.subnet_mac[3]:<10}\n")
-    this.header_file.write(f"{define_prefix + ' RC_ROVECOMM_SUBNET_MAC_FIFTH_BYTE':<50}{this.subnet_mac[4]:<10}\n")
 
     this.header_file.write("\n\n")
 

--- a/src/manifest_parser.py
+++ b/src/manifest_parser.py
@@ -81,6 +81,11 @@ if __name__ == "__main__":
     this.manifest_file = open("manifest.json", "r").read()
     this.manifest_file = json.loads(this.manifest_file)
 
+    # Check manifest spec version
+    if this.manifest_file["ManifestSpecVersion"] != 3:
+        print("Expected Manifest Spec v3, Aborting")
+        return
+
     # Manifest contains additional info not necessary for header file
     this.manifest = this.manifest_file["RovecommManifest"]
     this.header_file = open("RoveCommManifest.h", "w")


### PR DESCRIPTION
Update manifest format and allow all octets of IPs to vary. Prepare for VLAN spanning trees. Lots of autoformatting.