### PR TITLE
Add latest commit of manifest submodule

### DIFF
--- a/src/RoveCommEthernet/RoveCommEthernetTCP.cpp
+++ b/src/RoveCommEthernet/RoveCommEthernetTCP.cpp
@@ -81,9 +81,9 @@ bool RoveCommEthernetTCP::read(RoveCommPacket &dest) {
         if (rovecomm::unpackPacket(dest, readBuf)) return true;
 
         if (dest.dataId == RC_ROVECOMM_PING_DATA_ID) {
-            // Echo the packet as it came in
-            _writeTo(static_cast<rovecomm::data_type_t>(dest.dataType), RC_ROVECOMM_PING_REPLY_DATA_ID, dest.dataCount,
-                     dest.data, client.remoteIP(), RC_ROVECOMM_ETHERNET_UDP_PORT);
+            // Send back the time of last commit of manifest submodule
+            _writeTo(rovecomm::UINT32_T, RC_ROVECOMM_PING_REPLY_DATA_ID, 1,
+                     RC_MANIFEST_TIME, client.remoteIP(), RC_ROVECOMM_ETHERNET_UDP_PORT);
         }
     }
     // No clients with data were found

--- a/src/RoveCommEthernet/RoveCommEthernetUDP.cpp
+++ b/src/RoveCommEthernet/RoveCommEthernetUDP.cpp
@@ -65,9 +65,9 @@ bool RoveCommEthernetUDP::read(RoveCommPacket &dest) {
             }
         }
     } else if (dest.dataId == RC_ROVECOMM_PING_DATA_ID) {
-        // Echo the packet as it came in
-        _writeTo(static_cast<rovecomm::data_type_t>(dest.dataType), RC_ROVECOMM_PING_REPLY_DATA_ID, dest.dataCount,
-                 dest.data, remoteIP, RC_ROVECOMM_ETHERNET_UDP_PORT);
+        // Send back the time of last commit
+        _writeTo(rovecomm::CHAR, RC_ROVECOMM_PING_REPLY_DATA_ID, 1,
+                 RC_MANIFEST_TIME, remoteIP, RC_ROVECOMM_ETHERNET_UDP_PORT);
     }
     return true;
 }

--- a/src/RoveCommEthernet/RoveCommEthernetUDP.cpp
+++ b/src/RoveCommEthernet/RoveCommEthernetUDP.cpp
@@ -65,8 +65,8 @@ bool RoveCommEthernetUDP::read(RoveCommPacket &dest) {
             }
         }
     } else if (dest.dataId == RC_ROVECOMM_PING_DATA_ID) {
-        // Send back the time of last commit
-        _writeTo(rovecomm::CHAR, RC_ROVECOMM_PING_REPLY_DATA_ID, 1,
+        // Send back the time of last commit of manifest submodule
+        _writeTo(rovecomm::UINT32_T, RC_ROVECOMM_PING_REPLY_DATA_ID, 1,
                  RC_MANIFEST_TIME, remoteIP, RC_ROVECOMM_ETHERNET_UDP_PORT);
     }
     return true;

--- a/src/RoveCommManifest.h
+++ b/src/RoveCommManifest.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <IPAddress.h>
 
+#define RC_MANIFEST_TIME                                    "2026-02-22 11:38:25+00:00"
 #define RC_COREBOARD_FIRSTOCTET                             192       
 #define RC_COREBOARD_SECONDOCTET                            168       
 #define RC_COREBOARD_THIRDOCTET                             2         

--- a/src/RoveCommManifest.h
+++ b/src/RoveCommManifest.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include <IPAddress.h>
 
-#define RC_MANIFEST_TIME                                    "2026-02-22 11:38:25+00:00"
+#define RC_MANIFEST_TIME                                    1771280511
 #define RC_COREBOARD_FIRSTOCTET                             192       
 #define RC_COREBOARD_SECONDOCTET                            168       
 #define RC_COREBOARD_THIRDOCTET                             2         

--- a/src/manifest_parser.py
+++ b/src/manifest_parser.py
@@ -1,6 +1,7 @@
 import json
 import sys
-
+import subprocess
+from datetime import datetime, timezone
 
 # Define some c specific #defines and file header
 define_prefix = "#define"
@@ -39,6 +40,22 @@ this.manifest = None
 this.manifest_file = None
 this.header_file = None
 
+def insert_commit_time():
+    # Get time of last commit
+    commit_time = subprocess.run(["git", "log", "-1", "--format=%ci"], capture_output=True, text=True).stdout.strip()
+
+    # Convert string to datetime
+    dt = datetime.strptime(commit_time, "%Y-%m-%d %H:%M:%S %z")
+
+    # Convert to UTC datetime
+    utc_dt = dt.astimezone(timezone.utc)
+
+    # Make it a string for the macro
+    utc_string = f'"{utc_dt}"'
+
+    this.header_file.write(
+        f"{define_prefix + ' RC_MANIFEST_TIME':<60}{utc_string:<10}\n"
+    )
 
 def insert_packets(board, type):
     """
@@ -84,6 +101,8 @@ def insert_enums(board):
             output = output[:-1] #Removing "," from the last element of the enum 
             this.header_file.write(f"{output + '};'} \n")
 
+
+
 if __name__ == "__main__":
     # Load the json file
     this.manifest_file = open("../manifest/manifest.json", "r").read()
@@ -98,6 +117,10 @@ if __name__ == "__main__":
     this.manifest = this.manifest_file["RovecommManifest"]
     this.header_file = open("RoveCommManifest.h", "w")
     this.header_file.write(header)
+
+    insert_commit_time()
+
+
 
     # Write all the Ips and Ports together
     for board in this.manifest:
@@ -122,6 +145,8 @@ if __name__ == "__main__":
             f"{define_prefix + ' RC_'+board.upper()+'BOARD'+'_IPADDRESS':<60}{'{'+ip.replace('.', ', ')+'}':<10}\n"
         )
         this.header_file.write("\n")
+
+    
 
     # A couple of newlines between IP assignments and rovecomm messages
     this.header_file.write("\n\n")

--- a/src/manifest_parser.py
+++ b/src/manifest_parser.py
@@ -42,19 +42,10 @@ this.header_file = None
 
 def insert_commit_time():
     # Get time of last commit
-    commit_time = subprocess.run(["git", "log", "-1", "--format=%ci"], capture_output=True, text=True).stdout.strip()
-
-    # Convert string to datetime
-    dt = datetime.strptime(commit_time, "%Y-%m-%d %H:%M:%S %z")
-
-    # Convert to UTC datetime
-    utc_dt = dt.astimezone(timezone.utc)
-
-    # Make it a string for the macro
-    utc_string = f'"{utc_dt}"'
+    commit_time = subprocess.run(["git", "log", "-1", "--format=%ct", "--", "../manifest"], capture_output=True, text=True).stdout.strip()
 
     this.header_file.write(
-        f"{define_prefix + ' RC_MANIFEST_TIME':<60}{utc_string:<10}\n"
+        f"{define_prefix + ' RC_MANIFEST_TIME':<60}{commit_time:<10}\n"
     )
 
 def insert_packets(board, type):


### PR DESCRIPTION
Edited the manifest parser to add the time of when the last commit was made to the manifest submodule (RC_MANIFEST_TIME). Changed the Rovecomm ping reply to return RC_MANIFEST_TIME instead of just echoing the message.